### PR TITLE
Fix for loop, that all pos are shown

### DIFF
--- a/get_position.py
+++ b/get_position.py
@@ -31,7 +31,7 @@ def main(args):
       with pyAPT.MTS50(serial_number=con[2]) as con:
         print('\tPosition (mm) = %.2f [enc:%d]'%(con.position(), con.position(raw=True)))
 
-      return 0
+    return 0
   else:
     print('\tNo APT controllers found. Maybe you need to specify a PID')
     return 1


### PR DESCRIPTION
I fixed the indentation such that all controllers are shown.
Otherwise, only the first is shown:

Before:
```
╰─➤  python get_position.py                         
Looking for APT controllers
Found FTDI Kinesis K-Cube  DC Driver S/N: 27504197
        Position (mm) = 0.00 [enc:0]
```

Now:
```
╰─➤  python get_position.py                        
Looking for APT controllers
Found FTDI Kinesis K-Cube  DC Driver S/N: 27504197
        Position (mm) = 0.00 [enc:0]
Found FTDI Kinesis K-Cube  DC Driver S/N: 27504145
        Position (mm) = 0.00 [enc:0]
Found FTDI Kinesis K-Cube  DC Driver S/N: 27504259
        Position (mm) = 0.00 [enc:0]
``` 